### PR TITLE
Resolve package installation issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "unity-py"
+name = "unity_py"
 version = "0.1.0"
 description = "Unity-Py is a Python client to simplify interactions with NASA's Unity Platform."
 authors = ["Anil Natha, Mike Gangl"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "unity python api"
+name = "unity-py"
 version = "0.1.0"
 description = "Unity-Py is a Python client to simplify interactions with NASA's Unity Platform."
 authors = ["Anil Natha, Mike Gangl"]


### PR DESCRIPTION
After unsuccessful attempts at determining what the issue was with our dependency/requirement lists that pip was complaining about, I determined that the package installation issue was actually due to an improperly formatted string for the `name` field in the `pyproject.toml` file.

For the time being, I changed the value of this string to be `unity_py`.