### PR TITLE
Initial Dockstore implementation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7,10 +7,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "certifi"
@@ -29,7 +29,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "colorama"
@@ -54,6 +54,14 @@ pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
+name = "giturlparse"
+version = "0.10.0"
+description = "A Git URL parsing module (supports parsing and rewriting)"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -74,8 +82,8 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pep517", "pyfakefs", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -116,8 +124,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
@@ -152,7 +160,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["railroad-diagrams", "jinja2"]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -187,7 +195,7 @@ python-versions = ">=3.7"
 pytest = ">=5.0"
 
 [package.extras]
-dev = ["pre-commit", "tox", "pytest-asyncio"]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "requests"
@@ -205,7 +213,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "tenacity"
@@ -243,8 +251,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
-brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -256,13 +264,13 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "ab1813dcf3615661ce26bf697944d74cfb68045f78070904652ba92152255c94"
+content-hash = "35ffe329a2996643b6ddffac0d0ffb3d5a37e3bc7ecd329eb411a206b1a1949b"
 
 [metadata.files]
 attrs = [
@@ -284,6 +292,10 @@ colorama = [
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
+giturlparse = [
+    {file = "giturlparse-0.10.0-py2.py3-none-any.whl", hash = "sha256:04ba1a3a099c3093fa8d24a422913c6a9b2c2cd22bcffc939cf72e3e98f672d7"},
+    {file = "giturlparse-0.10.0.tar.gz", hash = "sha256:2595ab291d30717cda8474b874c9fd509f1b9802ad7f6968c36a45e4b13eb337"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ packages = [
 python = "^3.7"
 requests = "^2.28.0"
 tenacity = "^8.0.1"
+giturlparse = "^0.10.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/unity_py/services/application_service.py
+++ b/unity_py/services/application_service.py
@@ -1,0 +1,307 @@
+import json
+import requests
+
+from functools import cached_property
+
+from abc import ABC, abstractmethod
+from enum import Enum
+
+from attrs import define, field
+from giturlparse import parse as parse_giturl
+
+
+class ApplicationCatalogAccessError(Exception):
+    "An error occuring when attempting to access an application catalog"
+    pass
+
+
+class WorkflowType(Enum):
+    """
+    Encapsulates the types of workflows that Unity supports. This may be a subset of
+    what the application catalog supports.
+    """
+    
+    CWL = "CWL"
+
+
+@define
+class ApplicationPackage(object):
+    """
+    Describes an application package either stored within an application catalog or that
+    can be registered with an application catalog.
+    """
+
+    # Required arguments
+    name: str
+    source_repository: str
+    workflow_path: str
+    
+    # Optional
+    id: str = None # Not yet commited to catalog
+    is_published: bool = False
+    description: str = ""
+    
+    workflow_type: str = field()
+    @workflow_type.default
+    def check_workflow_default(self):
+        return "CWL"
+    @workflow_type.validator
+    def check_workflow_type(self, attribute, value):
+        # This will raise a value error for us if value is not part of the WorkflowType Enum
+        _ = WorkflowType(value)
+
+
+@define
+class DockstoreApplicationPackage(ApplicationPackage):
+    """
+    Adds extra information only available to a application package stored within Dockstore
+    """
+    
+    # Closest Dockstore has to a name
+    dockstore_info: dict = field(kw_only=True)
+
+
+class ApplicationCatalog(ABC):
+    """
+    Abstract interface for interacting with an application catalog in an implementation agnostic way
+    """
+    
+    def __init__(self):
+        """
+        """
+        
+        pass
+
+    @abstractmethod
+    def application(self, app_id):
+        "Retrieve an ApplicationPackage from the catalog based on application id"
+        pass
+    
+    @abstractmethod
+    def application_list(self):
+        "Return a list of ApplicationPackage objects representing the applications the catalog knows about"
+        pass
+
+    @abstractmethod    
+    def register(self, application, publish=True):
+        "Register an ApplicationPackage object into the catalog, optionally publish it"
+        pass
+
+    @abstractmethod    
+    def unregister(self, application, delete=False):
+        "Unregister an ApplicationPackage object into the catalog, optionally delete it instead of just unpublishing"
+        pass
+
+    
+class DockstoreSourceMethod(Enum):
+    """
+    Encapsulates the enum strings that Dockstore uses for source control methods, translates from URL
+    
+    Values come from repo:
+    https://github.com/dockstore/dockstore
+    
+    File:
+    dockstore/dockstore-common/src/main/java/io/dockstore/common/SourceControl.java
+    
+    Parsing from a manualRegister in Dockstore occurs here:
+    https://github.com/dockstore/dockstore/blob/7c4c08b9eed85334d5998bb02bc5b651f95e1f15/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java#L1298
+    """
+    
+    DOCKSTORE = "dockstore.org"
+    GITHUB = "github.com"
+    BITBUCKET = "bitbucket.org"
+    GITLAB = "gitlab.com"
+    
+
+class DockstoreAppCatalog(ApplicationCatalog):
+    """
+    Implementation of an application catalog interface to the Dockstore application
+    """
+    
+    def __init__(self, api_url, token):
+        """
+        Creates a new DockstoreAppCatalog.
+        
+        api_url: Dockstore API URL
+        token: Token is a string that can be obtained from the Dockstore user Account screen 
+        """
+        
+        self.api_url = api_url
+        self.token = token
+        
+    @property
+    def _headers(self):
+        "Headers needed by the Dockstore API"
+        
+        return {
+            "accept": "application/json",
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+    
+    def _get(self, request_url):
+        
+        request_url = request_url.strip("/")
+        
+        response = requests.get(f"{self.api_url}/{request_url}", headers=self._headers)
+            
+        if response.status_code != 200:
+            raise ApplicationCatalogAccessError(f"GET operation to application catalog at {self.api_url}/{request_url} return unexpected status code: {response.status_code} with message: {response.content}")
+            
+        return response
+
+    def _post(self, request_url, params=None, data=None):
+        
+        request_url = request_url.strip("/")
+        
+        if data is not None:
+            response = requests.post(f"{self.api_url}/{request_url}", headers=self._headers, params=params, data=json.dumps(data))
+        else:
+            response = requests.post(f"{self.api_url}/{request_url}", headers=self._headers, params=params)
+            
+        if response.status_code != 200:
+            raise ApplicationCatalogAccessError(f"POST operation to application catalog at {self.api_url}/{request_url} return unexpected status code: {response.status_code} with message: {response.content} using params: {params}")
+            
+        return response
+    
+    def _delete(self, request_url):
+        
+        request_url = request_url.strip("/")
+        
+        response = requests.delete(f"{self.api_url}/{request_url}", headers=self._headers)
+            
+        if response.status_code != 200 and response.status_code != 204:
+            raise ApplicationCatalogAccessError(f"DELETE operation to application catalog at {self.api_url}/{request_url} return unexpected status code: {response.status_code} with message: {response.content}")
+            
+        return response
+    
+    @cached_property
+    def _user_info(self):
+        request_url = "/users/user"
+        return self._get(request_url).json()
+    
+    @property
+    def _user_id(self):
+        return self._user_info['id']
+    
+    def _application_from_json(self, json_dict):
+        
+        # Name when using manual registry is an extra string given
+        # after registry path
+        name = json_dict['full_workflow_path'].split("/")[-1]
+        
+        return DockstoreApplicationPackage(id=str(json_dict['id']),
+                                           name=name,
+                                           source_repository=json_dict['gitUrl'],
+                                           workflow_path=json_dict['workflow_path'],
+                                           is_published=json_dict['is_published'],
+                                           description=json_dict['description'],
+                                           dockstore_info=json_dict)
+    
+    def application(self, app_id):
+        request_url = f"/workflows/{app_id}"
+        return self._application_from_json(self._get(request_url).json())
+    
+    def application_list(self, for_user=False, published=None):
+        """
+        For Dockstore optionally filter the application list for the user belonging to the token
+        as well as restrict to just published applications.
+        
+        Unpublished applications can only be seen when using for_user=True
+        """
+        
+        if for_user or (published is not None and not published):
+            request_url = f"/users/{self._user_id}/workflows"
+        else:
+            request_url = "/workflows/published"
+            
+        app_list = []
+        for app_info in self._get(request_url).json():
+            # Searching for user workflows does not return the full 
+            # set of application information
+            if for_user:
+                app_obj = self.application(app_info['id'])
+            else:
+                app_obj = self._application_from_json(app_info)
+                
+            if published is None or published:
+                app_list.append(app_obj)
+
+        return app_list
+    
+    def register(self, application, publish=True):
+        
+        # Parse application source repository into components used for
+        # Dockstore /manualRegister
+        repo_attrs = parse_giturl(application.source_repository)
+        
+        git_registry = repo_attrs.host
+        git_version_control = DockstoreSourceMethod(repo_attrs.host).name
+        organization = repo_attrs.owner
+        repository_base = repo_attrs.repo
+        
+        # Extract other values in the form Dockstore expects
+        descriptor_type = application.workflow_type
+
+        workflow_path = application.workflow_path
+        workflow_name = application.name
+
+        params = {
+            'workflowRegistry': git_version_control,
+            'workflowPath': f"{organization}/{repository_base}",
+            'defaultWorkflowPath': workflow_path,
+            'workflowName': workflow_name,
+            'descriptorType': descriptor_type,
+            #'defaultTestParameterFilePath':, 
+        }
+
+        request_url = "/workflows/manualRegister"
+        
+        response = self._post(request_url, params)
+        
+        # Add id to the ApplicationPackage object
+        new_app_id = response.json()['id']
+        
+        # Refresh workflow to pull in CWL files
+        self._get(f"/workflows/{new_app_id}/refresh")
+
+        # Optionally publish workflow
+        if publish:
+            self._post(f"/workflows/{new_app_id}/publish", data={"published": True})
+        
+        return self.application(new_app_id)
+
+    def unregister(self, application, delete=False):
+    
+        # Unpublish application
+        self._post(f"/workflows/{application.id}/publish", data={"published": False})
+        
+        # Refresh the application object to consistently remove publish flag
+        application = self.application(application.id)
+    
+        # Optionally completely delete from Dockstore
+        if delete:
+            # Convert back to stub so it can be removed
+            self._get(f"/workflows/{application.id}/restub")
+    
+            # Parse application source repository into components used for
+            # Dockstore /delete
+            repo_attrs = parse_giturl(application.source_repository)
+
+            repository_base = repo_attrs.repo
+            workflow_name = application.name
+
+            git_registry = repo_attrs.host
+            organization = repo_attrs.owner
+
+            # Encode / in name / = %2F
+            request_repo = f"{repository_base}%2F{workflow_name}"
+            
+            request_url = f"/workflows/registries/{git_registry}/organizations/{organization}/repositories/{request_repo}"
+            
+            self._delete(request_url)
+            
+            application.id = None
+            application.dockstore_info = None
+        
+        return application


### PR DESCRIPTION
This PR address initial Dockstore functionality provided by James that allows unity-py to interface with Dockstore to:
1. Register Applications
2. Unregister Applications
3. Query Applications hosted in Dockstore.