### PR TITLE
Fix for issue #30: Add Dockstore API interface for retrieving application files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added capability to add files to published application catalogs
 * added dependency on pystac > 1.7.3 to unity-py
 * added addition of dataset properties to stac read/write
+* Added functionality to download latest available version of the application parameter files stored in the Dockstore [[30](https://github.com/unity-sds/unity-py/issues/30)]
 ### Fixed
 ### Changed
 * all assets written out to STAC items are made relative (if they are non-URIs, relative, or exist in the same directory tree of the STAC files)


### PR DESCRIPTION
Added `DockstoreAppCatalog.download_files()` method to download latest available version of the application.

The code is tested by `sounder-sips-tutorial/jupyter-notebooks/tutorials/dockstore_publish.ipynb` - has its own PR.