### PR TITLE
Features/update asset roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 --------
+## [0.3.0] - 2024-01-30 
+### Added
+### Fixed 
+### Changed
+* We now use the asset filename as the key into the assets, and use the "metadata" and "data" types as asset-roles: [69](https://github.com/unity-sds/unity-py/issues/69)
+### Removed
+### Security
+### Deprecated
+
 ## [0.2.2] - 2024-01-03 
 ### Added
 * Added project/venue support [5](https://github.com/unity-sds/unity-py/issues/58)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-## Unreleased 
+## Unreleased [0.3.0]
 ### Added
 ### Fixed
 * fixed an issue with encoding a json deploy request twice [71](https://github.com/unity-sds/unity-py/issues/71)
-### Changed
-### Removed
-### Security
-### Deprecated
-
-
---------
-## [0.3.0] - 2024-01-30 
-### Added
-### Fixed 
 ### Changed
 * We now use the asset filename as the key into the assets, and use the "metadata" and "data" types as asset-roles: [69](https://github.com/unity-sds/unity-py/issues/69)
 ### Removed
 ### Security
 ### Deprecated
+
 
 ## [0.2.2] - 2024-01-03 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * fixed an issue with encoding a json deploy request twice [71](https://github.com/unity-sds/unity-py/issues/71)
 ### Changed
-* We now use the asset filename as the key into the assets, and use the "metadata" and "data" types as asset-roles: [69](https://github.com/unity-sds/unity-py/issues/69)
+* We now use the asset URI/HREF as the key into the assets, and use the "metadata" and "data" types as asset-roles: [69](https://github.com/unity-sds/unity-py/issues/69)
 ### Removed
 ### Security
 ### Deprecated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unity-sds-client"
-version = "0.2.2"
+version = "0.3.0"
 description = "Unity-Py is a Python client to simplify interactions with NASA's Unity Platform."
 authors = ["Anil Natha, Mike Gangl"]
 readme = "README.md"

--- a/tests/test_files/SNDR.SS1330.CHIRP.20160829T2317.m06.g233.L1_AQ.std.v02_48.G.200425130422.json
+++ b/tests/test_files/SNDR.SS1330.CHIRP.20160829T2317.m06.g233.L1_AQ.std.v02_48.G.200425130422.json
@@ -24,13 +24,21 @@
     }
   ],
   "assets": {
-    "data": {
+    "SNDR.SS1330.CHIRP.20160829T2317.m06.g233.L1_AQ.std.v02_48.G.200425130422.nc": {
       "href": "/unity/ads/sounder_sips/chirp_test_data/SNDR.SS1330.CHIRP.20160829T2317.m06.g233.L1_AQ.std.v02_48.G.200425130422.nc",
-      "title": "Main Data File"
+      "title": "Main Data File",
+      "description": "",
+      "roles": [
+        "data"
+      ]
     },
-    "metadata_stac": {
+    "SNDR.SS1330.CHIRP.20160829T2317.m06.g233.L1_AQ.std.v02_48.G.200425130422.json": {
       "href": "/unity/ads/sounder_sips/chirp_test_data/SNDR.SS1330.CHIRP.20160829T2317.m06.g233.L1_AQ.std.v02_48.G.200425130422.json",
-      "title": "Metadata STAC File"
+      "title": "Metadata STAC File",
+      "description": "",
+      "roles": [
+        "metadata"
+      ]
     }
   },
   "bbox": "",

--- a/tests/test_unity_stac.py
+++ b/tests/test_unity_stac.py
@@ -26,15 +26,16 @@ def test_read_stac():
     # Added 8/10/23 to check the STAC collection information
     assert datasets[1].collection_id == 'C2011289787-GES_DISC'
 
-    data_files = collection.data_locations()
+    data_files = collection.data_files()
     assert len(data_files) == 6
-    data_files = collection.data_locations(["data","opendap"])
+    data_files = collection.data_files(["data","opendap"])
+    assert len(data_files) == 2
+    data_files = collection.data_files(["data","opendap","metadata"])
     assert len(data_files) == 4
-    data_files = collection.data_locations(["data","opendap","metadata"])
-    assert len(data_files) == 6
     data_files = collection.data_locations(["data"])
     assert len(data_files) == 2
-    for x in data_files:
+    data_locations = collection.data_locations(["data"])
+    for x in data_locations:
         assert x in ['https://data.gesdisc.earthdata.nasa.gov/data/CHIRP/SNDR13CHRP1.2/2016/235/SNDR.SS1330.CHIRP.20160822T0005.m06.g001.L1_AQ.std.v02_48.G.200425095850.nc', 'https://data.gesdisc.earthdata.nasa.gov/data/CHIRP/SNDR13CHRP1.2/2016/235/SNDR.SS1330.CHIRP.20160822T0011.m06.g002.L1_AQ.std.v02_48.G.200425095901.nc']
 
     #Try a "classic" catalog + item files stac catalog

--- a/tests/test_unity_stac.py
+++ b/tests/test_unity_stac.py
@@ -50,10 +50,10 @@ def test_read_stac():
     assert len(data_files) == 2
     data_files = collection.data_files(["data"])
     assert len(data_files) == 1
-    assert data_files[0].type == "data"
+    assert data_files[0].roles == ["data"]
     data_files = collection.data_files(["metadata"])
     assert len(data_files) == 1
-    assert data_files[0].type == "metadata"
+    assert data_files[0].roles == ["metadata"]
 
 
 def test_write_stac():

--- a/tests/test_unity_stac.py
+++ b/tests/test_unity_stac.py
@@ -37,19 +37,22 @@ def test_read_stac():
     for x in data_files:
         assert x in ['https://data.gesdisc.earthdata.nasa.gov/data/CHIRP/SNDR13CHRP1.2/2016/235/SNDR.SS1330.CHIRP.20160822T0005.m06.g001.L1_AQ.std.v02_48.G.200425095850.nc', 'https://data.gesdisc.earthdata.nasa.gov/data/CHIRP/SNDR13CHRP1.2/2016/235/SNDR.SS1330.CHIRP.20160822T0011.m06.g002.L1_AQ.std.v02_48.G.200425095901.nc']
 
-        #Try a "classic" catalog + item files stac catalog
+    #Try a "classic" catalog + item files stac catalog
     collection = Collection.from_stac("tests/test_files/catalog_01.json")
     datasets = collection.datasets
     # Added 8/10/23 to check the STAC collection information
     assert datasets[0].collection_id == 'collection_test'
     assert len(datasets) == 1
-    data_files = collection.data_locations()
+    data_files = collection.data_files()
     assert len(data_files) == 2
-    data_files = collection.data_locations(["data"])
+    data_files = collection.data_files(["data", "metadata"])
+    assert len(data_files) == 2
+    data_files = collection.data_files(["data"])
     assert len(data_files) == 1
-    data_files = collection.data_locations(["metadata_stac"])
+    assert data_files[0].type == "data"
+    data_files = collection.data_files(["metadata"])
     assert len(data_files) == 1
-    assert data_files[0] == "/unity/ads/sounder_sips/chirp_test_data/SNDR.SS1330.CHIRP.20160829T2317.m06.g233.L1_AQ.std.v02_48.G.200425130422.json"
+    assert data_files[0].type == "metadata"
 
 
 def test_write_stac():

--- a/unity_sds_client/envs/environments.cfg
+++ b/unity_sds_client/envs/environments.cfg
@@ -1,7 +1,7 @@
 [DEV]
-client_id = 2phr7qsbf1k3i9l38288n35ale
+client_id = 40c2s0ulbhp9i0fmaph3su9jch
 auth_endpoint = https://cognito-idp.us-west-2.amazonaws.com
-unity_href = d3vc8w9zcq658.cloudfront.net
+unity_href = https://d3vc8w9zcq658.cloudfront.net/
 
 [TEST]
 client_id = 71894molftjtie4dvvkbjeard0
@@ -9,7 +9,7 @@ auth_endpoint = https://cognito-idp.us-west-2.amazonaws.com
 unity_href = https://dxebrgu0bc9w7.cloudfront.net/
 
 [PROD]
-client_id = 
+client_id = 7vehllplbone6p4usqgutqun35
 auth_endpoint = https://cognito-idp.us-west-2.amazonaws.com
 unity_href = https://d2zjsabg0fonik.cloudfront.net/
 

--- a/unity_sds_client/resources/collection.py
+++ b/unity_sds_client/resources/collection.py
@@ -42,6 +42,24 @@ class Collection(object):
                 List of dataset objects
         """
         return self._datasets
+    
+    def data_files(self, type=[]):
+        """
+            A method to list all assets (data, metdata, etc)
+            Parameters
+            ----------
+            type : List of Strings
+                List of "stac asset roles" to filter on. commonly ["data"] is of most importance
+
+            Returns
+            -------
+            files
+                List of returned datafiles
+        """
+        if len(type) == 0:
+            return [file for files in [x.datafiles for x in self._datasets] for file in files]
+        else:
+            return [file for files in [x.datafiles for x in self._datasets] for file in files if file.type in type]
 
     def data_locations(self, type=[]):
         """
@@ -49,7 +67,7 @@ class Collection(object):
             Parameters
             ----------
             type : List of Strings
-                List of "stac asset keys" to filter on. commonly ["data"] is of most importance
+                List of "stac asset roles" to filter on. commonly ["data"] is of most importance
 
             Returns
             -------
@@ -59,7 +77,7 @@ class Collection(object):
         if len(type) == 0:
             return [file.location for files in [x.datafiles for x in self._datasets] for file in files]
         else:
-            return [file.location for files in [x.datafiles for x in self._datasets] for file in files if file.type in type  ]
+            return [file.location for files in [x.datafiles for x in self._datasets] for file in files if file.type in type]
 
     def is_uri(path):
         if(path.startswith(tuple(["http:","https:","s3:"]))):
@@ -85,32 +103,38 @@ class Collection(object):
         for dataset in collection._datasets:
             updated = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
             item = Item(
-            id=dataset.id,
-            geometry=dataset.geometry,
-            bbox=dataset.bbox,
-            collection=dataset.collection_id,
-            datetime = date_parser.parse(dataset.data_begin_time),
-            properties={
-                "datetime": dataset.data_begin_time,
-                "start_datetime": dataset.data_begin_time,
-                "end_datetime":dataset.data_end_time,
-                "created": dataset.data_create_time if dataset.data_create_time!= None else updated,
-                "updated": updated
-            },
-
+                id=dataset.id,
+                geometry=dataset.geometry,
+                bbox=dataset.bbox,
+                collection=dataset.collection_id,
+                datetime = date_parser.parse(dataset.data_begin_time),
+                properties={
+                    "datetime": dataset.data_begin_time,
+                    "start_datetime": dataset.data_begin_time,
+                    "end_datetime":dataset.data_end_time,
+                    "created": dataset.data_create_time if dataset.data_create_time!= None else updated,
+                    "updated": updated
+                },
             )
             item.properties.update(dataset.properties)
             catalog.add_item(item)
 
             for df in dataset.datafiles:
+                
                 if(Collection.is_uri(df.location)):
                     item_location = df.location
                 else:
                     item_location = df.location.replace(data_dir,".")
+
                 item.add_asset(
-                    # key="data", asset=pystac.Asset(href=f,title="Main Data File", media_type=pystac.MediaType.HDF5)
-                    key=df.type, asset=Asset(href=item_location,title="{} file".format(df.type))
+                    key = item_location.rsplit("/",1)[1],
+                    asset = Asset(
+                        href = item_location,
+                        title = "{} file".format(df.type),
+                        description = "",
+                        roles = [df.type]
                     )
+                )
 
         from pystac.layout import TemplateLayoutStrategy
         write_dir = data_dir
@@ -183,12 +207,15 @@ class Collection(object):
 
                 for asset_key in item.assets:
                     asset = item.assets[asset_key]
+                    asset_role = asset.roles[0] if asset.roles is not None else ""
+                    asset_title = asset.title if asset.title is not None else ""
+                    asset_description = asset.description if asset.description is not None else ""
                     if(Collection.is_uri(asset.href)):
-                        ds.add_data_file(DataFile(asset_key ,asset.href))
+                        ds.add_data_file(DataFile(asset_role, asset.href, title=asset_title, description=asset_description))
                     elif(os.path.isabs(asset.href)):
-                        ds.add_data_file(DataFile(asset_key ,asset.href))
+                        ds.add_data_file(DataFile(asset_role, asset.href, title=asset_title, description=asset_description))
                     else:
-                        ds.add_data_file(DataFile(asset_key ,os.path.join(stac_dir, asset.href)))
+                        ds.add_data_file(DataFile(asset_role, os.path.join(stac_dir, asset.href), title=asset_title, description=asset_description))
 
                 collection._datasets.append(ds)
             return collection

--- a/unity_sds_client/resources/collection.py
+++ b/unity_sds_client/resources/collection.py
@@ -206,10 +206,15 @@ class Collection(object):
                 ds.properties.update(item.properties)
 
                 for asset_key in item.assets:
+
                     asset = item.assets[asset_key]
-                    asset_role = asset.roles[0] if asset.roles is not None else ""
-                    asset_title = asset.title if asset.title is not None else ""
-                    asset_description = asset.description if asset.description is not None else ""
+                    asset_role = asset.roles[0] if asset.roles is not None else None
+                    asset_title = asset.title if asset.title is not None else None
+                    asset_description = asset.description if asset.description is not None else None
+
+                    if asset_role is None and asset_key in ["data", "metadata"]:
+                        asset_role = asset_key
+
                     if(Collection.is_uri(asset.href)):
                         ds.add_data_file(DataFile(asset_role, asset.href, title=asset_title, description=asset_description))
                     elif(os.path.isabs(asset.href)):

--- a/unity_sds_client/resources/collection.py
+++ b/unity_sds_client/resources/collection.py
@@ -132,7 +132,7 @@ class Collection(object):
                         href = item_location,
                         title = "{} file".format(df.type),
                         description = "",
-                        roles = [df.role]
+                        roles = [df.roles]
                     )
                 )
 

--- a/unity_sds_client/resources/collection.py
+++ b/unity_sds_client/resources/collection.py
@@ -127,7 +127,7 @@ class Collection(object):
                     item_location = df.location.replace(data_dir,".")
 
                 item.add_asset(
-                    key = item_location.rsplit("/",1)[1],
+                    key = item_location,
                     asset = Asset(
                         href = item_location,
                         title = "{} file".format(df.type),

--- a/unity_sds_client/resources/data_file.py
+++ b/unity_sds_client/resources/data_file.py
@@ -3,13 +3,14 @@ class DataFile(object):
     """
 
     def __str__(self):
-        return f'unity_sds_client.resources.DataFile(location={self.location},type={self.type})'
+        return f'unity_sds_client.resources.DataFile(location={self.location})'
 
     def __repr__(self):
         return self.__str__()
 
-    def __init__(self, type, location, title = "", description = "" ):
-        self.type = type
-        self.location = location
-        self.title = title
+    def __init__(self, type, location, roles = [], title = "", description = "" ):
         self.description = description
+        self.location = location
+        self.roles = roles
+        self.title = title
+        self.type = type

--- a/unity_sds_client/resources/data_file.py
+++ b/unity_sds_client/resources/data_file.py
@@ -3,11 +3,13 @@ class DataFile(object):
     """
 
     def __str__(self):
-        return f'unity_sds_client.resources.DataFile(location={self.location})'
+        return f'unity_sds_client.resources.DataFile(location={self.location},type={self.type})'
 
     def __repr__(self):
         return self.__str__()
 
-    def __init__(self, type, location ):
+    def __init__(self, type, location, title = "", description = "" ):
         self.type = type
         self.location = location
+        self.title = title
+        self.description = description

--- a/unity_sds_client/services/data_service.py
+++ b/unity_sds_client/services/data_service.py
@@ -66,8 +66,14 @@ class DataService(object):
 
         for dataset in results:
             ds = Dataset(dataset['id'], collection.collection_id, dataset['properties']['start_datetime'], dataset['properties']['end_datetime'], dataset['properties']['created'])
-            ds.add_data_file(DataFile("data" ,dataset['assets']['data']['href']))
-            ds.add_data_file(DataFile("metadata" ,dataset['assets']['metadata__data']['href']))
+
+            for filename in dataset['assets']:
+                location = dataset['assets'][filename]['href']
+                file_type = dataset['assets'][filename]['type']
+                title = dataset['assets'][filename]['title']
+                description = dataset['assets'][filename]['description']
+                ds.add_data_file(DataFile(file_type, location, title=title, description=description))
+
             datasets.append(ds)
 
         return datasets

--- a/unity_sds_client/services/data_service.py
+++ b/unity_sds_client/services/data_service.py
@@ -63,16 +63,17 @@ class DataService(object):
         token = self._session.get_auth().get_token()
         response = requests.get(url, headers={"Authorization": "Bearer " + token})
         results = response.json()['features']
-
+        
         for dataset in results:
             ds = Dataset(dataset['id'], collection.collection_id, dataset['properties']['start_datetime'], dataset['properties']['end_datetime'], dataset['properties']['created'])
-
-            for filename in dataset['assets']:
-                location = dataset['assets'][filename]['href']
-                file_type = dataset['assets'][filename]['type']
-                title = dataset['assets'][filename]['title']
-                description = dataset['assets'][filename]['description']
-                ds.add_data_file(DataFile(file_type, location, title=title, description=description))
+            
+            for asset_key in dataset['assets']:
+                location = dataset['assets'][asset_key]['href']
+                file_type = dataset['assets'][asset_key].get('type', "")
+                title = dataset['assets'][asset_key].get('title', "")
+                description = dataset['assets'][asset_key].get('description', "")
+                roles = dataset['assets'][asset_key]["role"] if "role" in dataset['assets'][asset_key] else ["metadata"] if asset_key in ['metadata__cmr','metadata__data'] else [asset_key]
+                ds.add_data_file(DataFile(file_type, location, roles=roles, title=title, description=description))
 
             datasets.append(ds)
 

--- a/unity_sds_client/services/data_service.py
+++ b/unity_sds_client/services/data_service.py
@@ -72,7 +72,7 @@ class DataService(object):
                 file_type = dataset['assets'][asset_key].get('type', "")
                 title = dataset['assets'][asset_key].get('title', "")
                 description = dataset['assets'][asset_key].get('description', "")
-                roles = dataset['assets'][asset_key]["role"] if "role" in dataset['assets'][asset_key] else ["metadata"] if asset_key in ['metadata__cmr','metadata__data'] else [asset_key]
+                roles = dataset['assets'][asset_key]["roles"] if "roles" in dataset['assets'][asset_key] else ["metadata"] if asset_key in ['metadata__cmr','metadata__data'] else [asset_key]
                 ds.add_data_file(DataFile(file_type, location, roles=roles, title=title, description=description))
 
             datasets.append(ds)


### PR DESCRIPTION
## Purpose

Updated dataset asset lists so that we now use the URI/HREF of the asset as the key in the list the assets. The role/type of the data (e.g. "metadata", "data", etc.) is now an attribute of the asset with a key of "roles".

## Proposed Changes
- [CHANGE] Use href as unique keys for list of assets instead of asset role
## Issues
- #67 
- #69 
## Testing
- Tested using built-in unit tests