### PR TITLE
roles is already an array, removed "array of array"

### DIFF
--- a/unity_sds_client/resources/collection.py
+++ b/unity_sds_client/resources/collection.py
@@ -132,7 +132,7 @@ class Collection(object):
                         href = item_location,
                         title = "{} file".format(df.type),
                         description = "",
-                        roles = [df.roles]
+                        roles = df.roles
                     )
                 )
 


### PR DESCRIPTION
Fix to the to_stac method where we take an existing array (df.roles) and wrapped it in another array(`[df.roles]`)

Our to_stac output looked like this:

```
 "/unity/ads/outputs/SBG-L2A-RESAMPLE/SISTER_AVNG_L2A_RSRFL_20220502T180901_001.bin": {
      "href": "/unity/ads/outputs/SBG-L2A-RESAMPLE/SISTER_AVNG_L2A_RSRFL_20220502T180901_001.bin",
      "title": "binary file",
      "description": "",
      "roles": [
        [
          "data"
        ]
      ]
    },
```

and it should look like this:
```
 "/unity/ads/outputs/SBG-L2A-RESAMPLE/SISTER_AVNG_L2A_RSRFL_20220502T180901_001.bin": {
      "href": "/unity/ads/outputs/SBG-L2A-RESAMPLE/SISTER_AVNG_L2A_RSRFL_20220502T180901_001.bin",
      "title": "binary file",
      "description": "",
      "roles": [
          "data"
      ]
    },
```
