### PR TITLE
Filename key

### DIFF
--- a/tests/test_unity_stac.py
+++ b/tests/test_unity_stac.py
@@ -3,6 +3,7 @@ from unity_sds_client.resources.collection import Collection, Dataset, DataFile
 import datetime
 import pytest
 import os
+import json
 
 @pytest.fixture
 def cleanup_update_test():
@@ -83,7 +84,8 @@ def test_unity_to_stac():
     #Add 2 files to the dataset
     dataset.add_data_file(DataFile("data","./file.nc"))
     dataset.add_data_file(DataFile("metadadata", "./file.xml"))
-    assert len(dataset.datafiles) == 2
+    dataset.add_data_file(DataFile("data", "./file.xml"))
+    assert len(dataset.datafiles) == 3
 
 
     # Add arbitrary metadata to the product
@@ -99,10 +101,18 @@ def test_unity_to_stac():
     dataset2.add_data_file(DataFile("metadadata",application_output_directory + "/file2.xml"))
     collection.add_dataset(dataset2)
 
-    assert len(dataset.datafiles) == 2
+    assert len(dataset.datafiles) == 3
     assert len(dataset2.datafiles) == 2
 
     Collection.to_stac(collection, application_output_directory)
+
+    # Test to make sure the keys don't start with './'
+
+    f = open(
+        application_output_directory + "/SNDR.SS1330.CHIRP.20230615T0131.m06.g001.L1_AQ_CAL.std.v02_54.G.200615152827.json")
+    raw_stac = json.load(f)
+    for k in raw_stac['assets'].keys():
+        assert k.startswith("./") is not True
 
 
     # Read in the just written stac file to confirm paths are absolute

--- a/unity_sds_client/resources/collection.py
+++ b/unity_sds_client/resources/collection.py
@@ -129,7 +129,7 @@ class Collection(object):
                 key = item_location
 
                 if key.startswith("./"):
-                    key = key.replace("./", "")
+                    key = os.path.basename(key)
 
                 item.add_asset(
                     key = key,

--- a/unity_sds_client/resources/collection.py
+++ b/unity_sds_client/resources/collection.py
@@ -124,10 +124,15 @@ class Collection(object):
                 if(Collection.is_uri(df.location)):
                     item_location = df.location
                 else:
-                    item_location = df.location.replace(data_dir,".")
+                    item_location = df.location.replace(data_dir, ".")
+
+                key = item_location
+
+                if key.startswith("./"):
+                    key = key.replace("./", "")
 
                 item.add_asset(
-                    key = item_location,
+                    key = key,
                     asset = Asset(
                         href = item_location,
                         title = "{} file".format(df.type),


### PR DESCRIPTION
## Purpose

fixes an issue where U-DS was unable to update paths since they were expecting key == filename

when an asset is added with a relative path (e.g. ./myfile.txt) the asset key becomes "myfile.txt" instead of "./myfile.txt"
