### PR TITLE
Feature/add config override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased [0.3.0]
 ### Added
+* We've added the ability to override settings in the default config file by passing in a config file with the settings needing to be overridden when instantiating a Unity object. [56](https://github.com/unity-sds/unity-py/issues/56)
 ### Fixed
 * fixed an issue with encoding a json deploy request twice [71](https://github.com/unity-sds/unity-py/issues/71)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-## Unreleased [0.3.0]
+## Unreleased [0.4.0]
+
 ### Added
 * We've added the ability to override settings in the default config file by passing in a config file with the settings needing to be overridden when instantiating a Unity object. [56](https://github.com/unity-sds/unity-py/issues/56)
+### Fixed
+### Changed
+### Removed
+### Security
+### Deprecated
+
+
+## [0.3.0] - 2024-02-12
+### Added
 ### Fixed
 * fixed an issue with encoding a json deploy request twice [71](https://github.com/unity-sds/unity-py/issues/71)
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unity-sds-client"
-version = "0.3.0"
+version = "0.4.0"
 description = "Unity-Py is a Python client to simplify interactions with NASA's Unity Platform."
 authors = ["Anil Natha, Mike Gangl"]
 readme = "README.md"

--- a/tests/test_files/config_override.cfg
+++ b/tests/test_files/config_override.cfg
@@ -1,0 +1,2 @@
+[TEST]
+client_id = THIS_IS_A_TEST_CLIENT_ID

--- a/tests/test_unity_py.py
+++ b/tests/test_unity_py.py
@@ -16,6 +16,10 @@ def test_default_unity_client():
     client = Unity()
     assert True == True
 
+def test_unity_client_config_override():
+    client = Unity(config_file_override="tests/test_files/config_override.cfg")
+    setting = client._session._config.get("TEST","client_id")
+    assert setting == "THIS_IS_A_TEST_CLIENT_ID"
 
 @pytest.mark.regression
 def test_example_regression_test(cleanup_update_test):

--- a/unity_sds_client/unity.py
+++ b/unity_sds_client/unity.py
@@ -15,13 +15,15 @@ class Unity(object):
     is passed to different services and resources as needed.
     """
 
-    def __init__(self, environment: UnityEnvironments = UnityEnvironments.TEST):
+    def __init__(self, environment: UnityEnvironments = UnityEnvironments.TEST, config_file_override:str = None):
         """
         :param environment: the default environment for a session to work with. Defaults to 'TEST' unity environment.
+        :param config_file_override: absolute path to a config file containing settings to override default config
         """
         env = environment
         config = _read_config([
-            os.path.dirname(os.path.realpath(__file__)) + "/envs/environments.cfg".format(str(env.value).lower())
+            os.path.dirname(os.path.realpath(__file__)) + "/envs/environments.cfg".format(str(env.value).lower()),
+            config_file_override
         ])
         self._session = UnitySession(env.value, config)
 


### PR DESCRIPTION
## Purpose

From time to time Unity configuration settings need to be overridden, especially in Jupyter environments when testing Unity services.

## Proposed Changes
- [ADD] Ability to override default Unity configuration settings by passing in a config file containing the settings to override when instantiating a Unity object.
## Issues
- https://github.com/unity-sds/unity-py/issues/56
## Testing
- Added unit test with test configuration file to assert that overriding settings works as intended.
- Tested in jupyter environment