### PR TITLE
Add health service

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -44,13 +44,13 @@ jobs:
         UNITY_USER: '${{ secrets.UNITY_TEST_USER }}'
         UNITY_PASSWORD: '${{ secrets.UNITY_TEST_PASSWORD }}'
       run: |
-        poetry run pytest --cov=unity_sds_client -m "not regression"
+        poetry run pytest --cov-report=lcov --cov=unity_sds_client -m "not regression"
     - name: Regression Test with pytest
       env:
         UNITY_USER: '${{ secrets.UNITY_TEST_USER }}'
         UNITY_PASSWORD: '${{ secrets.UNITY_TEST_PASSWORD }}'
       run: |
-        poetry run pytest --cov=unity_sds_client -o log_cli=true --log-cli-level=DEBUG 
+        poetry run pytest --cov-report=lcov --cov=unity_sds_client -o log_cli=true --log-cli-level=DEBUG 
     - name: Coveralls
       uses: coverallsapp/github-action@v2.3.0
       with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -53,3 +53,5 @@ jobs:
         poetry run pytest --cov=unity_sds_client -o log_cli=true --log-cli-level=DEBUG 
     - name: Coveralls
       uses: coverallsapp/github-action@v2
+      with:
+        format: Pytest-Cov

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -53,5 +53,3 @@ jobs:
         poetry run pytest --cov-report=lcov --cov=unity_sds_client -o log_cli=true --log-cli-level=DEBUG 
     - name: Coveralls
       uses: coverallsapp/github-action@v2.3.0
-      with:
-        debug: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -52,6 +52,6 @@ jobs:
       run: |
         poetry run pytest --cov=unity_sds_client -o log_cli=true --log-cli-level=DEBUG 
     - name: Coveralls
-      uses: coverallsapp/github-action@v2
+      uses: coverallsapp/github-action@2.3.0
       with:
         debug: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -53,3 +53,25 @@ jobs:
         poetry run pytest --cov-report=lcov --cov=unity_sds_client -o log_cli=true --log-cli-level=DEBUG 
     - name: Coveralls
       uses: coverallsapp/github-action@v2.3.0
+  version:
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push' 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: "1.5.1"
+      - name: version-bump
+        run: |
+          poetry version prerelease
+      - name: Commit Version Bump
+        run: |
+          git config --global user.name 'mdps bot'
+          git config --global user.email 'mdps@noreply.github.com'
+          git commit -am "development version bump. [skip actions]"
+          git push
+        
+

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -54,4 +54,5 @@ jobs:
     - name: Coveralls
       uses: coverallsapp/github-action@v2
       with:
-        format: Pytest-Cov
+        format: python
+        file: .coverage

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -54,5 +54,4 @@ jobs:
     - name: Coveralls
       uses: coverallsapp/github-action@v2
       with:
-        format: python
-        file: .coverage
+        debug: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -52,6 +52,6 @@ jobs:
       run: |
         poetry run pytest --cov=unity_sds_client -o log_cli=true --log-cli-level=DEBUG 
     - name: Coveralls
-      uses: coverallsapp/github-action@2.3.0
+      uses: coverallsapp/github-action@v2.3.0
       with:
         debug: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased (0.5.0)
+
+### Added
+* Health Service with variuos functions that allow user's to inspect the health status of the system
+### Fixed
+### Changed
+* Health status information is included when an instantiated unity object is printed.
+### Removed
+### Security
+### Deprecated
+
+
 ## [0.4.0] - 2024-03-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unity-sds-client"
-version = "0.5.0"
+version = "0.5.0a0"
 description = "Unity-Py is a Python client to simplify interactions with NASA's Unity Platform."
 authors = ["Anil Natha, Mike Gangl"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unity-sds-client"
-version = "0.4.0"
+version = "0.5.0"
 description = "Unity-Py is a Python client to simplify interactions with NASA's Unity Platform."
 authors = ["Anil Natha, Mike Gangl"]
 readme = "README.md"

--- a/tests/test_unity_health_service.py
+++ b/tests/test_unity_health_service.py
@@ -37,3 +37,14 @@ def test_health_status_printing():
     s = Unity()
     health_service = s.client(UnityServices.HEALTH_SERVICE)
     health_service.print_health_status()
+
+@pytest.mark.regression
+def test_health_service_printing():
+    """
+    Test that when the health service client is printed, it outputs
+    the health status information
+    """
+    print("Example health status printing of health service object.")
+    s = Unity()
+    health_service = s.client(UnityServices.HEALTH_SERVICE)
+    print(health_service)

--- a/tests/test_unity_health_service.py
+++ b/tests/test_unity_health_service.py
@@ -9,13 +9,8 @@ from unity_sds_client.unity import Unity
 from unity_sds_client.unity_services import UnityServices
 
 
-@pytest.fixture
-def cleanup_update_test():
-    yield None
-    print("Cleanup...")
-
 @pytest.mark.regression
-def test_health_service_client_creation(cleanup_update_test):
+def test_health_service_client_creation():
     """
     Test that an instance of the health service can be instantiated.
     """
@@ -23,7 +18,7 @@ def test_health_service_client_creation(cleanup_update_test):
     health_service = s.client(UnityServices.HEALTH_SERVICE)
 
 @pytest.mark.regression
-def test_health_status_retrieval(cleanup_update_test):
+def test_health_status_retrieval():
     """
     Test that health statuses can be retrieved using the health service.
     """
@@ -34,7 +29,7 @@ def test_health_status_retrieval(cleanup_update_test):
     assert health_statuses is not None
 
 @pytest.mark.regression
-def test_health_status_printing(cleanup_update_test):
+def test_health_status_printing():
     """
     Test that health statuses can be printed using the health service.
     """

--- a/tests/test_unity_health_service.py
+++ b/tests/test_unity_health_service.py
@@ -25,10 +25,20 @@ def test_health_service_client_creation(cleanup_update_test):
 @pytest.mark.regression
 def test_health_status_retrieval(cleanup_update_test):
     """
-    Test that health statuses can be retrieved from the health service.
+    Test that health statuses can be retrieved using the health service.
     """
     print("Example health status check")
     s = Unity()
     health_service = s.client(UnityServices.HEALTH_SERVICE)
-    heatlh_statuses = health_service.get_health_status()
-    assert heatlh_statuses is not None
+    health_statuses = health_service.get_health_status()
+    assert health_statuses is not None
+
+@pytest.mark.regression
+def test_health_status_printing(cleanup_update_test):
+    """
+    Test that health statuses can be printed using the health service.
+    """
+    print("Example health status check")
+    s = Unity()
+    health_service = s.client(UnityServices.HEALTH_SERVICE)
+    health_service.print_health_status()

--- a/tests/test_unity_health_service.py
+++ b/tests/test_unity_health_service.py
@@ -1,0 +1,34 @@
+"""
+This module contains a set of tests is to ensure that the
+Unity Health Service is functional.
+"""
+
+import pytest
+
+from unity_sds_client.unity import Unity
+from unity_sds_client.unity_services import UnityServices
+
+
+@pytest.fixture
+def cleanup_update_test():
+    yield None
+    print("Cleanup...")
+
+@pytest.mark.regression
+def test_health_service_client_creation(cleanup_update_test):
+    """
+    Test that an instance of the health service can be instantiated.
+    """
+    s = Unity()
+    health_service = s.client(UnityServices.HEALTH_SERVICE)
+
+@pytest.mark.regression
+def test_health_status_retrieval(cleanup_update_test):
+    """
+    Test that health statuses can be retrieved from the health service.
+    """
+    print("Example health status check")
+    s = Unity()
+    health_service = s.client(UnityServices.HEALTH_SERVICE)
+    heatlh_statuses = health_service.get_health_status()
+    assert heatlh_statuses is not None

--- a/unity_sds_client/services/health_service.py
+++ b/unity_sds_client/services/health_service.py
@@ -85,7 +85,9 @@ class HealthService(object):
             service_name = service["service"]
             report = report + f"{service_name}\n"
             for status in service["healthChecks"]:
-                report = report + f"{status["date"]}: {status["status"]}\n"
+                service_status = status["status"]
+                service_status_date = status["date"]
+                report = report + f"{service_status_date}: {service_status}\n"
             report = report + "\n"
         
         return report

--- a/unity_sds_client/services/health_service.py
+++ b/unity_sds_client/services/health_service.py
@@ -82,7 +82,8 @@ class HealthService(object):
         report = f"\n\n{health_status_title}\n"
         report = report + len(health_status_title) * "-" + "\n\n"
         for service in self._health_statuses:
-            report = report + f"{service["service"]}\n"
+            service_name = service["service"]
+            report = report + f"{service_name}\n"
             for status in service["healthChecks"]:
                 report = report + f"{status["date"]}: {status["status"]}\n"
             report = report + "\n"

--- a/unity_sds_client/services/health_service.py
+++ b/unity_sds_client/services/health_service.py
@@ -25,6 +25,9 @@ class HealthService(object):
 
         self._health_statuses = None
 
+    def __str__(self):
+        return self.generate_health_status_report()
+
     def get_health_status(self):
         """
         Returns a list of services and their respective health status
@@ -67,18 +70,27 @@ class HealthService(object):
 
         return self._health_statuses
     
-    def print_health_status(self):
+    def generate_health_status_report(self):
+        """
+        Return a generated report of health status information
+        """
 
         if self._health_statuses is None:
             self.get_health_status()
 
-        health_status_title = "HEALTH STATUSES"
-        response = f"\n\n{health_status_title}\n"
-        response = response + len(health_status_title) * "-" + "\n\n"
+        health_status_title = "HEALTH STATUS REPORT"
+        report = f"\n\n{health_status_title}\n"
+        report = report + len(health_status_title) * "-" + "\n\n"
         for service in self._health_statuses:
-            response = response + f"{service["service"]}\n"
+            report = report + f"{service["service"]}\n"
             for status in service["healthChecks"]:
-                response = response + f"{status["date"]}: {status["status"]}\n"
-            response = response + "\n"
+                report = report + f"{status["date"]}: {status["status"]}\n"
+            report = report + "\n"
         
-        print(response)
+        return report
+
+    def print_health_status(self):
+        """
+        Print the health status report
+        """
+        print(f"{self.generate_health_status_report()}")

--- a/unity_sds_client/services/health_service.py
+++ b/unity_sds_client/services/health_service.py
@@ -23,6 +23,8 @@ class HealthService(object):
             List of applications and their health statses
         """
 
+        self._health_statuses = None
+
     def get_health_status(self):
         """
         Returns a list of services and their respective health status
@@ -30,7 +32,7 @@ class HealthService(object):
 
         # Get Health Information
         # Stubbed in health data until Health API endpoint is available
-        health_json = [
+        self._health_statuses = [
           {
             "service": "airflow",
             "landingPage":"https://unity.jpl.nasa.gov/project/venue/processing/ui",
@@ -63,4 +65,20 @@ class HealthService(object):
           }
         ]
 
-        return health_json
+        return self._health_statuses
+    
+    def print_health_status(self):
+
+        if self._health_statuses is None:
+            self.get_health_status()
+
+        health_status_title = "HEALTH STATUSES"
+        response = f"\n\n{health_status_title}\n"
+        response = response + len(health_status_title) * "-" + "\n\n"
+        for service in self._health_statuses:
+            response = response + f"{service["service"]}\n"
+            for status in service["healthChecks"]:
+                response = response + f"{status["date"]}: {status["status"]}\n"
+            response = response + "\n"
+        
+        print(response)

--- a/unity_sds_client/services/health_service.py
+++ b/unity_sds_client/services/health_service.py
@@ -1,0 +1,66 @@
+from unity_sds_client.unity_session import UnitySession
+
+class HealthService(object):
+    """
+    The HealthService class is a wrapper to Unity's Health API endpoints.
+    """
+
+    def __init__(
+        self,
+        session:UnitySession
+    ):
+        """
+        Initialize the HealthService class.
+
+        Parameters
+        ----------
+        session : UnitySession
+            The Unity Session that will be used to facilitate making calls to the Health endpoints.
+
+        Returns
+        -------
+        List
+            List of applications and their health statses
+        """
+
+    def get_health_status(self):
+        """
+        Returns a list of services and their respective health status
+        """
+
+        # Get Health Information
+        # Stubbed in health data until Health API endpoint is available
+        health_json = [
+          {
+            "service": "airflow",
+            "landingPage":"https://unity.jpl.nasa.gov/project/venue/processing/ui",
+            "healthChecks": [
+              {
+                "status": "HEALTHY",
+                "date": "2024-04-09T18:01:08Z"
+              }
+            ]
+          },
+          {
+            "service": "jupyter",
+            "landingPage":"https://unity.jpl.nasa.gov/project/venue/ads/jupyter",
+            "healthChecks": [
+              {
+                "status": "HEALTHY",
+                "date": "2024-04-09T18:01:08Z"
+              }
+            ]
+          },
+          {
+            "service": "other_service",
+            "landingPage":"https://unity.jpl.nasa.gov/project/venue/other_service",
+            "healthChecks": [
+              {
+                "status": "UNHEALTHY",
+                "date": "2024-04-09T18:01:08Z"
+              }
+            ]
+          }
+        ]
+
+        return health_json

--- a/unity_sds_client/unity.py
+++ b/unity_sds_client/unity.py
@@ -75,11 +75,14 @@ class Unity(object):
                 response = response + "{}: {}\n".format(setting, dict(config[section])[setting])
 
         health_service = self.client(UnityServices.HEALTH_SERVICE)
-        health_status_title = "Health Statuses"
+        health_status_title = "HEALTH STATUSES"
         response = response + "\n\n{}\n".format(health_status_title)
         response = response + len(health_status_title) * "-" + "\n\n"
         for service in health_service.get_health_status():
-            response = response + "{}: {}\n".format(service["service"], service["healthChecks"][0]["status"])
+            response = response + f"{service["service"]}\n"
+            for status in service["healthChecks"]:
+                response = response + f"{status["date"]}: {status["status"]}\n"
+            response = response + "\n"
 
         return response
 

--- a/unity_sds_client/unity.py
+++ b/unity_sds_client/unity.py
@@ -2,6 +2,7 @@ import os
 from configparser import ConfigParser, ExtendedInterpolation
 from unity_sds_client.services.data_service import DataService
 from unity_sds_client.services.process_service import ProcessService
+from unity_sds_client.services.health_service import HealthService
 from unity_sds_client.unity_session import UnitySession
 from unity_sds_client.unity_exception import UnityException
 from unity_sds_client.unity_environments import UnityEnvironments
@@ -55,21 +56,30 @@ class Unity(object):
         """
         if service_name == UnityServices.DATA_SERVICE:
             return DataService(session=self._session)
+        if service_name == UnityServices.HEALTH_SERVICE:
+            return HealthService(session=self._session)
         elif service_name == UnityServices.PROCESS_SERVICE:
             return ProcessService(session=self._session)
         else:
             raise UnityException("Invalid service name: " + str(service_name))
 
     def __str__(self):
-        response = "UNITY CONFIGURATION"
-        response = response + "\n\n" + len(response) * "-" + "\n"
+        response = "\nUNITY CONFIGURATION"
+        response = response + "\n" + len(response) * "-" + "\n"
         
         config = self._session.get_config()
         config_sections = config.sections()
         for section in config_sections:
-            response = response + "\n{}\n".format(section)
+            response = response + "\n[{}]\n".format(section)
             for setting in dict(config[section]):
                 response = response + "{}: {}\n".format(setting, dict(config[section])[setting])
+
+        health_service = self.client(UnityServices.HEALTH_SERVICE)
+        health_status_title = "Health Statuses"
+        response = response + "\n\n{}\n".format(health_status_title)
+        response = response + len(health_status_title) * "-" + "\n\n"
+        for service in health_service.get_health_status():
+            response = response + "{}: {}\n".format(service["service"], service["healthChecks"][0]["status"])
 
         return response
 

--- a/unity_sds_client/unity.py
+++ b/unity_sds_client/unity.py
@@ -74,15 +74,7 @@ class Unity(object):
             for setting in dict(config[section]):
                 response = response + "{}: {}\n".format(setting, dict(config[section])[setting])
 
-        health_service = self.client(UnityServices.HEALTH_SERVICE)
-        health_status_title = "HEALTH STATUSES"
-        response = response + "\n\n{}\n".format(health_status_title)
-        response = response + len(health_status_title) * "-" + "\n\n"
-        for service in health_service.get_health_status():
-            response = response + f"{service["service"]}\n"
-            for status in service["healthChecks"]:
-                response = response + f"{status["date"]}: {status["status"]}\n"
-            response = response + "\n"
+        response = response + self.client(UnityServices.HEALTH_SERVICE).generate_health_status_report()
 
         return response
 

--- a/unity_sds_client/unity_services.py
+++ b/unity_sds_client/unity_services.py
@@ -6,6 +6,7 @@ class UnityServices(Enum):
     The UnityServices class is used to specify a service, when needed, when interacting with the unity_sds_client package.
     """
 
-    DATA_SERVICE = "data_service"
     APPLICATION_SERVICE = "app_service"
+    DATA_SERVICE = "data_service"
+    HEALTH_SERVICE = "health_service"
     PROCESS_SERVICE = "process_service"


### PR DESCRIPTION
## Purpose

Initial implementation of a health service to convey the health state of the system. This implementation is using a stubbed in set of data until we can integrate an API call to fetch the health data for a given project/venue when the API endpoint is implemented.

## Proposed Changes
- Added Health Service that provides features to fetch and print the health state of the system.
- Changed printing of unity objects so that they include the health status report.
- Updated changelog and version number of unity-py, currently marked as 'unreleased' in CHANGELOG.
## Issues
- #86
## Testing
- Created initial unit tests to ensure fetching, report generation, and printing of health report are functional
